### PR TITLE
Rebasedbooking

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This is the backend REST API for booking/viewing workspaces
 - Get booking object with `user_id`
 
 ### GET /bookings/users/start/:start/end/:end
-- Get booking object with `start_time` and `end_time`
+- Get booking object with `start_time` and `end_time`, where `start_time` and `end_time` are unix timestamps.
 
 ### POST /bookings
 - Create new booking object

--- a/README.md
+++ b/README.md
@@ -16,3 +16,28 @@ This is the backend REST API for booking/viewing workspaces
 
 ### DELETE /workspaces/:id
 - Delete workspace object with `id`
+
+## Bookings
+### GET /bookings
+- Get All booking objects
+
+### GET /bookings/:id
+- Get booking object with `id`
+
+### GET /bookings/workspaces/:id
+- Get booking object with `workspace_id`
+
+### GET /bookings/users/:id
+- Get booking object with `user_id`
+
+### GET /bookings/users/start/:start/end/:end
+- Get booking object with `start_time` and `end_time`
+
+### POST /bookings
+- Create new booking object
+
+### PATCH /bookings/:id
+- Update booking object with `id`
+
+### DELETE /booking/:id
+- Delete booking object with `id`

--- a/db/data_store.go
+++ b/db/data_store.go
@@ -24,6 +24,8 @@ type bookingProvider interface {
 	GetAllBookings(id string) (*model.Booking, error)
 	GetBookingByWorkspaceID(id string) (*[]model.Booking, error)
 	GetBookingByUserID(id string) (*[]model.Booking, error)
+	GetBookingsByDateRange(start string, end string) (*[]model.Booking, error)
 	CreateBooking(booking *model.Booking) error
 	UpdateBooking(id string, booking *model.Booking) error
+	RemoveBooking(id string) error
 }

--- a/db/data_store.go
+++ b/db/data_store.go
@@ -8,7 +8,7 @@ var EmptyError = errors.New("empty")
 
 type DataStore struct {
 	WorkspaceProvider workspaceProvider
-	//BookingProvider   bookingProvider
+	BookingProvider   bookingProvider
 }
 
 type workspaceProvider interface {
@@ -21,9 +21,9 @@ type workspaceProvider interface {
 
 type bookingProvider interface {
 	GetOneBooking(id string) (*model.Booking, error)
-	GetAllBookings(id string) (*model.Booking, error)
-	GetBookingByWorkspaceID(id string) (*[]model.Booking, error)
-	GetBookingByUserID(id string) (*[]model.Booking, error)
+	GetAllBookings() (*model.Booking, error)
+	GetBookingsByWorkspaceID(id string) (*[]model.Booking, error)
+	GetBookingsByUserID(id string) (*[]model.Booking, error)
 	GetBookingsByDateRange(start string, end string) (*[]model.Booking, error)
 	CreateBooking(booking *model.Booking) error
 	UpdateBooking(id string, booking *model.Booking) error

--- a/db/data_store.go
+++ b/db/data_store.go
@@ -1,6 +1,9 @@
 package db
 
-import "errors"
+import (
+	"errors"
+	"time"
+)
 import "go-api/model"
 
 var NotFoundError = errors.New("not found")
@@ -21,10 +24,10 @@ type workspaceProvider interface {
 
 type bookingProvider interface {
 	GetOneBooking(id string) (*model.Booking, error)
-	GetAllBookings() (*model.Booking, error)
-	GetBookingsByWorkspaceID(id string) (*[]model.Booking, error)
-	GetBookingsByUserID(id string) (*[]model.Booking, error)
-	GetBookingsByDateRange(start string, end string) (*[]model.Booking, error)
+	GetAllBookings() ([]*model.Booking, error)
+	GetBookingsByWorkspaceID(id string) ([]*model.Booking, error)
+	GetBookingsByUserID(id string) ([]*model.Booking, error)
+	GetBookingsByDateRange(start time.Time, end time.Time) ([]*model.Booking, error)
 	CreateBooking(booking *model.Booking) error
 	UpdateBooking(id string, booking *model.Booking) error
 	RemoveBooking(id string) error

--- a/db/local_db.go
+++ b/db/local_db.go
@@ -7,6 +7,43 @@ type LocalDBStore struct {
 	bookings map[string]*model.Booking
 }
 
+func (l LocalDBStore) GetBookingsByDateRange(start string, end string) ([]*model.Booking, error) {
+	var list []*model.Booking
+	if len(l.bookings) < 1 {
+		return nil, EmptyError
+	}
+	for _, b := range l.bookings {
+		list = append(list, b)
+	}
+	return list, nil
+}
+
+func (l LocalDBStore) GetBookingsByUserID(id string) ([]*model.Booking, error) {
+	var list []*model.Booking
+	if len(l.bookings) < 1 {
+		return nil, EmptyError
+	}
+	for _, b := range l.bookings {
+		if b.UserID == id {
+			list = append(list, b)
+		}
+	}
+	return list, nil
+}
+
+func (l LocalDBStore) GetBookingsByWorkspaceID(id string) ([]*model.Booking, error) {
+	var list []*model.Booking
+	if len(l.bookings) < 1 {
+		return nil, EmptyError
+	}
+	for _, b := range l.bookings {
+		if b.WorkspaceID == id {
+			list = append(list, b)
+		}
+	}
+	return list, nil
+}
+
 func (l LocalDBStore) GetOneWorkspace(id string) (*model.Workspace, error) {
 	w, ok := l.workspaces[id]
 	if !ok {
@@ -72,15 +109,15 @@ func (l LocalDBStore) UpdateBooking(id string, booking *model.Booking) error {
 	if booking.UserID != "" {
 		l.bookings[id].UserID = booking.WorkspaceID
 	}
-	if booking.StartDate != nil {
+	if booking.StartDate.IsZero() {
 		l.bookings[id].StartDate = booking.StartDate
 	}
-	if booking.EndDate != nil {
+	if booking.EndDate.IsZero() {
 		l.bookings[id].EndDate = booking.EndDate
 	}
-	if booking.Canceled != nil {
-		l.bookings[id].Canceled = booking.Canceled
-	}
+	//if booking.Canceled != nil {
+	//	l.bookings[id].Canceled = booking.Canceled
+	//}
 	return nil
 }
 
@@ -129,23 +166,6 @@ func NewLocalDataStore() *DataStore {
 				Props: nil,
 			},
 		}},
-		BookingProvider: &LocalDBStore{bookings: map[string]*model.Booking{
-			"1": {
-				ID:    "1",
-				WorkspaceID:  "1",
-				UserID: nil, // Not Implemented!
-				StartDate: "2020/01/30",
-				EndDate: "2020/01/30", // One day booking
-				Canceled: false,
-			},
-			"2": {
-				ID:    "2",
-				WorkspaceID:  "2",
-				UserID: nil, // Not Implemented!
-				StartDate: "2020/01/28",
-				EndDate: "2020/01/30", // Range booking
-				Canceled: true, // Canceled
-			},
-		}},
+		BookingProvider: nil,
 	}
 }

--- a/db/local_db.go
+++ b/db/local_db.go
@@ -4,6 +4,7 @@ import "go-api/model"
 
 type LocalDBStore struct {
 	workspaces map[string]*model.Workspace
+	bookings map[string]*model.Booking
 }
 
 func (l LocalDBStore) GetOneWorkspace(id string) (*model.Workspace, error) {
@@ -52,6 +53,58 @@ func (l LocalDBStore) GetAllWorkspaces() ([]*model.Workspace, error) {
 	return list, nil
 }
 
+func (l LocalDBStore) GetOneBooking(id string) (*model.Booking, error) {
+	b, ok := l.bookings[id]
+	if !ok {
+		return nil, NotFoundError
+	}
+	return b, nil
+}
+
+func (l LocalDBStore) UpdateBooking(id string, booking *model.Booking) error {
+	_, ok := l.bookings[id]
+	if !ok {
+		return NotFoundError
+	}
+	if booking.WorkspaceID != "" {
+		l.bookings[id].WorkspaceID = booking.WorkspaceID
+	}
+	if booking.UserID != "" {
+		l.bookings[id].UserID = booking.WorkspaceID
+	}
+	if booking.StartDate != nil {
+		l.bookings[id].StartDate = booking.StartDate
+	}
+	if booking.EndDate != nil {
+		l.bookings[id].EndDate = booking.EndDate
+	}
+	if booking.Canceled != nil {
+		l.bookings[id].Canceled = booking.Canceled
+	}
+	return nil
+}
+
+func (l LocalDBStore) CreateBooking(booking *model.Booking) error {
+	l.bookings[booking.ID] = booking
+	return nil
+}
+
+func (l LocalDBStore) RemoveBooking(id string) error {
+	delete(l.bookings, id)
+	return nil
+}
+
+func (l LocalDBStore) GetAllBookings() ([]*model.Booking, error) {
+	var list []*model.Booking
+	if len(l.bookings) < 1 {
+		return nil, EmptyError
+	}
+	for _, w := range l.bookings {
+		list = append(list, w)
+	}
+	return list, nil
+}
+
 func NewLocalDataStore() *DataStore {
 	return &DataStore{
 		WorkspaceProvider: &LocalDBStore{workspaces: map[string]*model.Workspace{
@@ -74,6 +127,24 @@ func NewLocalDataStore() *DataStore {
 				ID:    "6",
 				Name:  "Workspace 6",
 				Props: nil,
+			},
+		}},
+		BookingProvider: &LocalDBStore{bookings: map[string]*model.Booking{
+			"1": {
+				ID:    "1",
+				WorkspaceID:  "1",
+				UserID: nil, // Not Implemented!
+				StartDate: "2020/01/30",
+				EndDate: "2020/01/30", // One day booking
+				Canceled: false,
+			},
+			"2": {
+				ID:    "2",
+				WorkspaceID:  "2",
+				UserID: nil, // Not Implemented!
+				StartDate: "2020/01/28",
+				EndDate: "2020/01/30", // Range booking
+				Canceled: true, // Canceled
 			},
 		}},
 	}

--- a/model/models.go
+++ b/model/models.go
@@ -15,5 +15,5 @@ type Booking struct {
 	UserID      string    `json:"user_id"`
 	StartDate   time.Time `json:"start_time"`
 	EndDate     time.Time `json:"end_time"`
-	Canceled    bool      `json:"cancelled"`
+	Cancelled    bool      `json:"cancelled"`
 }

--- a/routes/app.go
+++ b/routes/app.go
@@ -21,6 +21,7 @@ func NewApp() *App {
 func (app *App) Setup(port string) error {
 	app.router.HandleFunc("/", app.index)
 	app.RegisterWorkspaceRoutes()
+	app.RegisterBookingRoutes()
 	return http.ListenAndServe(":"+port, app.router)
 }
 

--- a/routes/booking.go
+++ b/routes/booking.go
@@ -115,14 +115,18 @@ func (app *App) GetBookingsByDateRange(w http.ResponseWriter, r *http.Request) {
 	queryParams := r.URL.Query()
 	start := queryParams["start"][0]
 	end := queryParams["end"][0]
-	_, err_start := time.Parse(time.RFC3339, start) // Assumes format "2006-01-02T15:04:05Z" or "2006-01-02T15:04:05+07:00"
-	_, err_end := time.Parse(time.RFC3339, end)
-	if err_start != nil || err_end != nil {
-		log.Printf("App.GetBookingsByDateRange - error getting bookings by date range from provider %v", err)
+	_, errStart := time.Parse(time.RFC3339, start) // Assumes format "2006-01-02T15:04:05Z" or "2006-01-02T15:04:05+07:00"
+	_, errEnd := time.Parse(time.RFC3339, end)
+	if errStart != nil {
+		log.Printf("App.GetBookingsByDateRange - error getting bookings by date range from provider %v", errStart)
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	
+	if errEnd != nil {
+		log.Printf("App.GetBookingsByDateRange - error getting bookings by date range from provider %v", errEnd)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
 	bookings, err := app.store.BookingProvider.GetBookingsByDateRange(start, end) // TODO: Send parsed instead?
 	if err != nil {
 		log.Printf("App.GetBookingsByDateRange - error getting bookings by date range from provider %v", err)

--- a/routes/booking.go
+++ b/routes/booking.go
@@ -7,12 +7,12 @@ import (
 func (app *App) RegisterBookingRoutes() {
 	app.router.HandleFunc("/bookings", app.CreateBooking).Methods("POST")
 	app.router.HandleFunc("/bookings/{id}", app.GetOneBooking).Methods("GET")
-	app.router.HandleFunc("/bookings/{workspace_id}", app.GetBookingsByWorkspaceID).Methods("GET")
-	app.router.HandleFunc("/bookings/{user_id}", app.GetBookingsByUserID).Methods("GET")
-	app.router.HandleFunc("/bookings/{start_time}/{end_time}", app.GetBookingsByDateRange).Methods("GET")
+	app.router.HandleFunc("/bookings/workspaces/{workspace_id}", app.GetBookingsByWorkspaceID).Methods("GET")
+	app.router.HandleFunc("/bookings/users/{user_id}", app.GetBookingsByUserID).Methods("GET")
+	app.router.HandleFunc("/bookings/start/{start_time}/end/{end_time}", app.GetBookingsByDateRange).Methods("GET")
 	app.router.HandleFunc("/bookings", app.GetAllBookings).Methods("GET")
 	app.router.HandleFunc("/bookings/{id}", app.UpdateBooking).Methods("PATCH")
-	app.router.HandleFunc("/bookings/{id}", app.DeleteBooking).Methods("DELETE")
+	app.router.HandleFunc("/bookings/{id}", app.RemoveBooking).Methods("DELETE")
 }
 
 func (app *App) CreateBooking(w http.ResponseWriter, r *http.Request) {
@@ -131,18 +131,18 @@ func (app *App) UpdateBooking(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (app *App) DeleteBooking(w http.ResponseWriter, r *http.Request) {
+func (app *App) RemoveBooking(w http.ResponseWriter, r *http.Request) {
 	bookingID := mux.Vars(r)["id"]
 
 	if bookingID == "" {
-		log.Printf("App.DeleteBooking - empty booking id")
+		log.Printf("App.RemoveBooking - empty booking id")
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
 	err := app.store.BookingProvider.RemoveBooking(bookingID)
 	if err != nil {
-		log.Printf("App.DeleteBooking - error getting all bookings from provider %v", err)
+		log.Printf("App.RemoveBooking - error getting all bookings from provider %v", err)
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}

--- a/routes/booking.go
+++ b/routes/booking.go
@@ -2,13 +2,12 @@ package routes
 
 import (
 	"encoding/json"
-	"fmt"
 	"github.com/gorilla/mux"
 	"go-api/model"
 	"io/ioutil"
 	"log"
 	"net/http"
-	"regexp"
+	"time"
 )
 
 func (app *App) RegisterBookingRoutes() {
@@ -116,14 +115,15 @@ func (app *App) GetBookingsByDateRange(w http.ResponseWriter, r *http.Request) {
 	queryParams := r.URL.Query()
 	start := queryParams["start"][0]
 	end := queryParams["end"][0]
-	re := regexp.MustCompile(`\d{4}\d{2}\d{2}`)
-	if re.MatchString(start) == false || re.MatchString(end) {
+	_, err_start := time.Parse(time.RFC3339, start) // Assumes format "2006-01-02T15:04:05Z" or "2006-01-02T15:04:05+07:00"
+	_, err_end := time.Parse(time.RFC3339, end)
+	if err_start != nil || err_end != nil {
 		log.Printf("App.GetBookingsByDateRange - error getting bookings by date range from provider %v", err)
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	
-	bookings, err := app.store.BookingProvider.GetBookingsByDateRange(start, end)
+	bookings, err := app.store.BookingProvider.GetBookingsByDateRange(start, end) // TODO: Send parsed instead?
 	if err != nil {
 		log.Printf("App.GetBookingsByDateRange - error getting bookings by date range from provider %v", err)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/routes/booking.go
+++ b/routes/booking.go
@@ -6,18 +6,145 @@ import (
 
 func (app *App) RegisterBookingRoutes() {
 	app.router.HandleFunc("/bookings", app.CreateBooking).Methods("POST")
-	app.router.HandleFunc("/bookings/{id}", app.GetBooking).Methods("GET")
+	app.router.HandleFunc("/bookings/{id}", app.GetOneBooking).Methods("GET")
+	app.router.HandleFunc("/bookings/{workspace_id}", app.GetBookingsByWorkspaceID).Methods("GET")
+	app.router.HandleFunc("/bookings/{user_id}", app.GetBookingsByUserID).Methods("GET")
+	app.router.HandleFunc("/bookings/{start_time}/{end_time}", app.GetBookingsByDateRange).Methods("GET")
 	app.router.HandleFunc("/bookings", app.GetAllBookings).Methods("GET")
+	app.router.HandleFunc("/bookings/{id}", app.UpdateBooking).Methods("PATCH")
+	app.router.HandleFunc("/bookings/{id}", app.DeleteBooking).Methods("DELETE")
 }
 
 func (app *App) CreateBooking(w http.ResponseWriter, r *http.Request) {
-	panic("TODO implement me")
+	var newBooking model.Booking
+	reqBody, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.Printf("App.CreateBooking - error reading request body %v", err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	err = json.Unmarshal(reqBody, &newBooking)
+	if err != nil {
+		log.Printf("App.CreateBooking - error unmarshaling request body %v", err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	err = app.store.BookingProvider.CreateBooking(&newBooking)
+	if err != nil {
+		log.Printf("App.CreateBooking - error creating booking %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(newBooking)
 }
 
-func (app *App) GetBooking(w http.ResponseWriter, r *http.Request) {
-	panic("TODO implement me")
+func (app *App) GetOneBooking(w http.ResponseWriter, r *http.Request) {
+	bookingID := mux.Vars(r)["id"]
+
+	if bookingID == "" {
+		log.Printf("App.GetOneBooking - empty booking id")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	booking, err := app.store.BookingProvider.GetOneBooking(bookingID)
+	if err != nil {
+		log.Printf("App.GetOneBooking - error getting booking from provider %v", err)
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(booking)
 }
 
 func (app *App) GetAllBookings(w http.ResponseWriter, r *http.Request) {
-	panic("TODO implement me")
+	bookings, err := app.store.BookingProvider.GetAllBookings()
+	if err != nil {
+		log.Printf("App.GetAllBookings - error getting all bookings from provider %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	json.NewEncoder(w).Encode(bookings)
+}
+
+func (app *App) GetBookingsByWorkspaceID(w http.ResponseWriter, r *http.Request) {
+	bookings, err := app.store.BookingProvider.GetBookingsByWorkspaceID()
+	if err != nil {
+		log.Printf("App.GetBookingsByWorkspaceID - error getting bookings by workspaceID from provider %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	json.NewEncoder(w).Encode(bookings)
+}
+
+func (app *App) GetBookingsByUserID(w http.ResponseWriter, r *http.Request) {
+	bookings, err := app.store.BookingProvider.GetBookingsByUserID()
+	if err != nil {
+		log.Printf("App.GetBookingsByUserID - error getting bookings by userID from provider %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	json.NewEncoder(w).Encode(bookings)
+}
+
+func (app *App) GetBookingsByDateRange(w http.ResponseWriter, r *http.Request) {
+	bookings, err := app.store.BookingProvider.GetBookingsByDateRange()
+	if err != nil {
+		log.Printf("App.GetBookingsByDateRange - error getting bookings by date range from provider %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	json.NewEncoder(w).Encode(bookings)
+}
+
+func (app *App) UpdateBooking(w http.ResponseWriter, r *http.Request) {
+	bookingID := mux.Vars(r)["id"]
+
+	if bookingID == "" {
+		log.Printf("App.UpdateBooking - empty booking id")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	var updatedBooking model.Booking
+	reqBody, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.Printf("App.UpdateBooking - error reading request body %v", err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	err = json.Unmarshal(reqBody, &updatedBooking)
+	if err != nil {
+		log.Printf("App.UpdateBooking - error unmarshaling request body %v", err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	err = app.store.BookingProvider.UpdateBooking(bookingID, &updatedBooking)
+	if err != nil {
+		log.Printf("App.UpdateBooking - error getting all bookings from provider %v", err)
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+}
+
+func (app *App) DeleteBooking(w http.ResponseWriter, r *http.Request) {
+	bookingID := mux.Vars(r)["id"]
+
+	if bookingID == "" {
+		log.Printf("App.DeleteBooking - empty booking id")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	err := app.store.BookingProvider.RemoveBooking(bookingID)
+	if err != nil {
+		log.Printf("App.DeleteBooking - error getting all bookings from provider %v", err)
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
 }

--- a/routes/booking.go
+++ b/routes/booking.go
@@ -115,8 +115,8 @@ func (app *App) GetBookingsByDateRange(w http.ResponseWriter, r *http.Request) {
 	queryParams := r.URL.Query()
 	start := queryParams["start"][0]
 	end := queryParams["end"][0]
-	_, errStart := time.Parse(time.RFC3339, start) // Assumes format "2006-01-02T15:04:05Z" or "2006-01-02T15:04:05+07:00"
-	_, errEnd := time.Parse(time.RFC3339, end)
+	startTime, errStart := time.Parse(time.UnixDate, start) // Unix Timestamp
+	endTime, errEnd := time.Parse(time.UnixDate, end)
 	if errStart != nil {
 		log.Printf("App.GetBookingsByDateRange - error getting bookings by date range from provider %v", errStart)
 		w.WriteHeader(http.StatusBadRequest)
@@ -127,7 +127,7 @@ func (app *App) GetBookingsByDateRange(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	bookings, err := app.store.BookingProvider.GetBookingsByDateRange(start, end) // TODO: Send parsed instead?
+	bookings, err := app.store.BookingProvider.GetBookingsByDateRange(startTime, endTime) // TODO: Send parsed instead?
 	if err != nil {
 		log.Printf("App.GetBookingsByDateRange - error getting bookings by date range from provider %v", err)
 		w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
Additional comments:
Right now the URI for getting bookings by date range is `/bookings/start/{start_time}/end/{end_time}`, which we can change if desired.

Do we want the owner of a booking to be a modifiable thing about a booking?

Currently in update we have repetition of the same code (for both workspaces and bookings). Could be changed to some form of enumeration of the incoming fields such that it's more scalable in the future.

Will we later on have options for "Update all bookings with filter __" "Delete all bookings with filter __"? I.e. Delete all bookings made by this user. 

We could minimize repeated code with workspaces and bookings: Currently most of the functions (i.e. update) do literally the same thing. Delete is done by ID for both. Would there be a way for us to condense this?
