### PR TITLE
decouple workspace and assignee

### DIFF
--- a/db/postgres/availability.go
+++ b/db/postgres/availability.go
@@ -1,7 +1,6 @@
 package postgres
 
 import (
-	"database/sql"
 	"log"
 	"time"
 )
@@ -12,7 +11,7 @@ func (p PostgresDBStore) FindAvailability(floorId string, start time.Time, end t
 	// $3 = end
 
 	sqlStmtBookings := `SELECT b.workspace_id from bookings b INNER JOIN workspaces w ON w.id=b.workspace_id
-			WHERE w.floor_id=$1 AND w.locked=false AND 
+			WHERE w.floor_id=$1 AND w.locked=false AND b.cancelled=false AND
 			( (b.start_time <= $2 AND b.end_time >= $2) 
 				OR (b.start_time >= $2 AND b.end_time <= $3) 
 				OR (b.end_time >= $3 AND b.start_time <= $3) );`
@@ -36,11 +35,11 @@ func (p PostgresDBStore) FindAvailability(floorId string, start time.Time, end t
 	}
 
 	sqlStmtOfferings := `SELECT o.workspace_id from offerings o INNER JOIN workspaces w ON w.id=o.workspace_id
-			WHERE w.floor_id=$1 AND w.locked=false AND 
+			WHERE w.floor_id=$1 AND w.locked=false AND o.cancelled=false AND
 			( (o.start_time <= $2 AND o.end_time >= $3) );`
 	rows, err = p.database.Query(sqlStmtOfferings, floorId, start, end)
 	if err != nil {
-		log.Printf("PostgresDBStore.FindAvailability.getOfferings: %v, sqlStatement: %s\n", err, sqlStmtBookings)
+		log.Printf("PostgresDBStore.FindAvailability.getOfferings: %v, sqlStatement: %s\n", err, sqlStmtOfferings)
 		return nil, err
 	}
 	defer rows.Close()
@@ -52,12 +51,38 @@ func (p PostgresDBStore) FindAvailability(floorId string, start time.Time, end t
 		)
 		if err != nil {
 			// dont cause panic here, log it
-			log.Printf("PostgresDBStore.FindAvailability.getOfferings: %v, sqlStatement: %s\n", err, sqlStmtBookings)
+			log.Printf("PostgresDBStore.FindAvailability.getOfferings: %v, sqlStatement: %s\n", err, sqlStmtOfferings)
 		}
 		offeredWorkspaces[id] = true
 	}
 
-	sqlStmtAll := `SELECT id, user_id from workspaces where floor_id=$1;`
+	sqlStmtAssigned := `SELECT wa.workspace_id from workspace_assignee wa INNER JOIN workspaces w ON w.id=wa.workspace_id
+			WHERE w.floor_id=$1 AND w.locked=false AND
+			( (wa.start_time <= $2 AND wa.end_time >= $2) 
+				OR (wa.start_time >= $2 AND wa.end_time <= $3) 
+				OR (wa.end_time >= $3 AND wa.start_time <= $3)
+			    OR (wa.end_time IS NULL AND wa.start_time < $2)
+			    OR (wa.end_time IS NULL AND wa.start_time > $2 AND wa.start_time < $3));`
+	rows, err = p.database.Query(sqlStmtAssigned, floorId, start, end)
+	if err != nil {
+		log.Printf("PostgresDBStore.FindAvailability.getAssignee: %v, sqlStatement: %s\n", err, sqlStmtAssigned)
+		return nil, err
+	}
+	defer rows.Close()
+	assignedWorkspaces := make(map[string]bool)
+	for rows.Next() {
+		var id string
+		err := rows.Scan(
+			&id,
+		)
+		if err != nil {
+			// dont cause panic here, log it
+			log.Printf("PostgresDBStore.FindAvailability.getAssignee: %v, sqlStatement: %s\n", err, sqlStmtAssigned)
+		}
+		assignedWorkspaces[id] = true
+	}
+
+	sqlStmtAll := `SELECT id from workspaces where floor_id=$1;`
 	rows, err = p.database.Query(sqlStmtAll, floorId)
 	if err != nil {
 		log.Printf("PostgresDBStore.FindAvailability: %v, sqlStatement: %s\n", err, sqlStmtAll)
@@ -67,10 +92,8 @@ func (p PostgresDBStore) FindAvailability(floorId string, start time.Time, end t
 	availableWorkspaces := make([]string, 0)
 	for rows.Next() {
 		var id string
-		var userId sql.NullString
 		err := rows.Scan(
 			&id,
-			&userId,
 		)
 		if err != nil {
 			// dont cause panic here, log it
@@ -78,7 +101,7 @@ func (p PostgresDBStore) FindAvailability(floorId string, start time.Time, end t
 		}
 		_, offered := offeredWorkspaces[id]
 		_, booked := bookedWorkspaces[id]
-		assigned := userId.Valid
+		_, assigned := assignedWorkspaces[id]
 		if assigned && offered && !booked {
 			availableWorkspaces = append(availableWorkspaces, id)
 		} else if !assigned && !booked {

--- a/db/postgres/workspaces.go
+++ b/db/postgres/workspaces.go
@@ -1,22 +1,17 @@
 package postgres
 
 import (
-	"database/sql"
 	"go-api/model"
 	"log"
 )
 
 func (p PostgresDBStore) GetOneWorkspace(id string) (*model.Workspace, error) {
-	sqlStatement := `SELECT id, name, floor_id, user_id FROM workspaces WHERE id=$1;`
+	sqlStatement := `SELECT id, name, floor_id FROM workspaces WHERE id=$1;`
 	var workspace model.Workspace
-	var userId sql.NullString
 	row := p.database.QueryRow(sqlStatement, id)
-	err := row.Scan(&workspace.ID, &workspace.Name, &workspace.Floor, &userId)
+	err := row.Scan(&workspace.ID, &workspace.Name, &workspace.Floor)
 	if err != nil {
 		return nil, err
-	}
-	if userId.Valid {
-		workspace.User = userId.String
 	}
 	return &workspace, nil
 }
@@ -54,7 +49,7 @@ func (p PostgresDBStore) RemoveWorkspace(id string) error {
 }
 
 func (p PostgresDBStore) GetAllWorkspaces() ([]*model.Workspace, error) {
-	rows, err := p.database.Query(`SELECT id, name, floor_id, user_id FROM workspaces;`)
+	rows, err := p.database.Query(`SELECT id, name, floor_id FROM workspaces;`)
 	if err != nil {
 		return nil, err
 	}
@@ -62,14 +57,10 @@ func (p PostgresDBStore) GetAllWorkspaces() ([]*model.Workspace, error) {
 	workspaces := make([]*model.Workspace, 0)
 	for rows.Next() {
 		var workspace model.Workspace
-		var userId sql.NullString
-		err = rows.Scan(&workspace.ID, &workspace.Name, &workspace.Floor, &userId)
+		err = rows.Scan(&workspace.ID, &workspace.Name, &workspace.Floor)
 		if err != nil {
 			// dont cause panic here, log it
 			log.Printf("PostgresDBStore.GetAllWorkspaces: %v\n", err)
-		}
-		if userId.Valid {
-			workspace.User = userId.String
 		}
 		workspaces = append(workspaces, &workspace)
 	}

--- a/fixtures/workspaces.sql
+++ b/fixtures/workspaces.sql
@@ -1,19 +1,28 @@
 INSERT
-INTO workspaces (id, floor_id, user_id, name, locked)
+INTO workspaces (id, floor_id, name, locked)
 VALUES (uuid_generate_v3(uuid_ns_url(), 'https://www.i.work/workspaces/1'),
-        uuid_generate_v3(uuid_ns_url(), 'https://www.i.work/floors/1'), null, 'W-001', false),
+        uuid_generate_v3(uuid_ns_url(), 'https://www.i.work/floors/1'), 'W-001', false),
        (uuid_generate_v3(uuid_ns_url(), 'https://www.i.work/workspaces/2'),
-        uuid_generate_v3(uuid_ns_url(), 'https://www.i.work/floors/1'), null, 'W-002', false),
+        uuid_generate_v3(uuid_ns_url(), 'https://www.i.work/floors/1'), 'W-002', false),
        (uuid_generate_v3(uuid_ns_url(), 'https://www.i.work/workspaces/3'),
-        uuid_generate_v3(uuid_ns_url(), 'https://www.i.work/floors/1'),
-        uuid_generate_v3(uuid_ns_url(), 'https://www.i.work/users/clark'), 'W-003', false),
+        uuid_generate_v3(uuid_ns_url(), 'https://www.i.work/floors/1'), 'W-003', false),
        (uuid_generate_v3(uuid_ns_url(), 'https://www.i.work/workspaces/4'),
-        uuid_generate_v3(uuid_ns_url(), 'https://www.i.work/floors/1'),
-        uuid_generate_v3(uuid_ns_url(), 'https://www.i.work/users/bruce'), 'W-004', false),
+        uuid_generate_v3(uuid_ns_url(), 'https://www.i.work/floors/1'), 'W-004', false),
        (uuid_generate_v3(uuid_ns_url(), 'https://www.i.work/workspaces/5'),
-        uuid_generate_v3(uuid_ns_url(), 'https://www.i.work/floors/1'),
-        uuid_generate_v3(uuid_ns_url(), 'https://www.i.work/users/diana'), 'W-005', false),
+        uuid_generate_v3(uuid_ns_url(), 'https://www.i.work/floors/1'), 'W-005', false),
        (uuid_generate_v3(uuid_ns_url(), 'https://www.i.work/workspaces/6'),
-        uuid_generate_v3(uuid_ns_url(), 'https://www.i.work/floors/1'), null, 'W-006', false),
+        uuid_generate_v3(uuid_ns_url(), 'https://www.i.work/floors/1'), 'W-006', false),
        (uuid_generate_v3(uuid_ns_url(), 'https://www.i.work/workspaces/7'),
-        uuid_generate_v3(uuid_ns_url(), 'https://www.i.work/floors/1'), null, 'W-007', false);
+        uuid_generate_v3(uuid_ns_url(), 'https://www.i.work/floors/1'), 'W-007', false);
+
+INSERT
+INTO workspace_assignee (id, user_id, workspace_id, start_time, end_time)
+VALUES (uuid_generate_v3(uuid_ns_url(), 'https://www.i.work/assignee/1'),
+        uuid_generate_v3(uuid_ns_url(), 'https://www.i.work/users/clark'),
+        uuid_generate_v3(uuid_ns_url(), 'https://www.i.work/workspaces/3'), '2018-12-01T00:00:00Z', null),
+       (uuid_generate_v3(uuid_ns_url(), 'https://www.i.work/assignee/2'),
+        uuid_generate_v3(uuid_ns_url(), 'https://www.i.work/users/bruce'),
+        uuid_generate_v3(uuid_ns_url(), 'https://www.i.work/workspaces/4'), '2018-12-01T00:00:00Z', null),
+       (uuid_generate_v3(uuid_ns_url(), 'https://www.i.work/assignee/3'),
+        uuid_generate_v3(uuid_ns_url(), 'https://www.i.work/users/diana'),
+        uuid_generate_v3(uuid_ns_url(), 'https://www.i.work/workspaces/5'), '2018-12-01T00:00:00Z', null);

--- a/model/models.go
+++ b/model/models.go
@@ -6,7 +6,6 @@ type Workspace struct {
 	ID    string                 `json:"id"`
 	Name  string                 `json:"name"`
 	Floor string                 `json:"floor_id"`
-	User  string                 `json:"user_id"`
 	Props map[string]interface{} `json:"props"`
 }
 

--- a/resources/tables.sql
+++ b/resources/tables.sql
@@ -1,5 +1,6 @@
 DROP TABLE IF EXISTS offerings;
 DROP TABLE IF EXISTS bookings;
+DROP TABLE IF EXISTS workspace_assignee;
 DROP TABLE IF EXISTS workspaces;
 DROP TABLE IF EXISTS users;
 DROP TABLE IF EXISTS floors;
@@ -23,8 +24,7 @@ CREATE TABLE workspaces
 (
     id       uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
     floor_id uuid REFERENCES floors (id) NOT NULL,
-    user_id  uuid REFERENCES users (id),
-    name     VARCHAR(32)                        NOT NULL,
+    name     VARCHAR(32)                 NOT NULL,
     locked   BOOLEAN          DEFAULT FALSE
 );
 
@@ -34,8 +34,8 @@ CREATE TABLE bookings
     user_id      uuid REFERENCES users (id)      NOT NULL,
     workspace_id uuid REFERENCES workspaces (id) NOT NULL,
     cancelled    BOOLEAN          DEFAULT FALSE,
-    start_time   TIMESTAMPTZ                            NOT NULL,
-    end_time     TIMESTAMPTZ                            NOT NULL
+    start_time   TIMESTAMPTZ                     NOT NULL,
+    end_time     TIMESTAMPTZ                     NOT NULL
 );
 
 CREATE TABLE offerings
@@ -44,6 +44,15 @@ CREATE TABLE offerings
     user_id      uuid REFERENCES users (id)      NOT NULL,
     workspace_id uuid REFERENCES workspaces (id) NOT NULL,
     cancelled    BOOLEAN          DEFAULT FALSE,
-    start_time   TIMESTAMPTZ                            NOT NULL,
-    end_time     TIMESTAMPTZ                            NOT NULL
+    start_time   TIMESTAMPTZ                     NOT NULL,
+    end_time     TIMESTAMPTZ                     NOT NULL
 );
+
+CREATE TABLE workspace_assignee
+(
+    id           uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id      uuid REFERENCES users (id)      NOT NULL,
+    workspace_id uuid REFERENCES workspaces (id) NOT NULL,
+    start_time   TIMESTAMPTZ                     NOT NULL,
+    end_time     TIMESTAMPTZ
+)


### PR DESCRIPTION
This makes it so that the `workspace` table does not contain any notion of `users` and creates yet another table called `workspace_assignee` that manages the timeframe where a workspace is assigned to a person. This will allow users to switch seats without causing any issues in our representation